### PR TITLE
Axel Fohlin

### DIFF
--- a/homeassistant/components/humidifier/intent.py
+++ b/homeassistant/components/humidifier/intent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import voluptuous as vol
 
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE, STATE_OFF
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import config_validation as cv, intent
 
 from . import (
@@ -20,6 +20,35 @@ from . import (
 
 INTENT_HUMIDITY = "HassHumidifierSetpoint"
 INTENT_MODE = "HassHumidifierMode"
+
+
+def _match_humidifier_entity(
+    intent_obj: intent.Intent,
+    slots: dict,
+) -> tuple[State, dict]:
+    """Match humidifier entity and prepare service data.
+
+    Returns:
+        Tuple of (matched state, service_data dict)
+    """
+    hass = intent_obj.hass
+
+    match_constraints = intent.MatchTargetsConstraints(
+        name=slots["name"]["value"],
+        domains=[DOMAIN],
+        assistant=intent_obj.assistant,
+    )
+    match_result = intent.async_match_targets(hass, match_constraints)
+
+    if not match_result.is_match:
+        raise intent.MatchFailedError(
+            result=match_result, constraints=match_constraints
+        )
+
+    state = match_result.states[0]
+    service_data = {ATTR_ENTITY_ID: state.entity_id}
+
+    return state, service_data
 
 
 async def async_setup_intents(hass: HomeAssistant) -> None:
@@ -43,21 +72,7 @@ class HumidityHandler(intent.IntentHandler):
         """Handle the hass intent."""
         hass = intent_obj.hass
         slots = self.async_validate_slots(intent_obj.slots)
-
-        match_constraints = intent.MatchTargetsConstraints(
-            name=slots["name"]["value"],
-            domains=[DOMAIN],
-            assistant=intent_obj.assistant,
-        )
-        match_result = intent.async_match_targets(hass, match_constraints)
-        if not match_result.is_match:
-            raise intent.MatchFailedError(
-                result=match_result, constraints=match_constraints
-            )
-
-        state = match_result.states[0]
-        service_data = {ATTR_ENTITY_ID: state.entity_id}
-
+        state, service_data = _match_humidifier_entity(intent_obj, slots)
         humidity = slots["humidity"]["value"]
 
         if state.state == STATE_OFF:
@@ -98,19 +113,7 @@ class SetModeHandler(intent.IntentHandler):
         """Handle the hass intent."""
         hass = intent_obj.hass
         slots = self.async_validate_slots(intent_obj.slots)
-        match_constraints = intent.MatchTargetsConstraints(
-            name=slots["name"]["value"],
-            domains=[DOMAIN],
-            assistant=intent_obj.assistant,
-        )
-        match_result = intent.async_match_targets(hass, match_constraints)
-        if not match_result.is_match:
-            raise intent.MatchFailedError(
-                result=match_result, constraints=match_constraints
-            )
-
-        state = match_result.states[0]
-        service_data = {ATTR_ENTITY_ID: state.entity_id}
+        state, service_data = _match_humidifier_entity(intent_obj, slots)
 
         intent.async_test_feature(state, HumidifierEntityFeature.MODES, "modes")
         mode = slots["mode"]["value"]


### PR DESCRIPTION
Axel Fohlin

Description of the issue:
The `HumidityHandler` and `SetModeHandler` classes contain a duplicated code block for entity matching.

Motivation:
By extracting the duplicated code block into a shared helper function, it enhances code maintainability and reduces inconsistency risks. Duplicated code blocks do not add value and make updates error-prone, changes must be made in multiple locations.

Solution:
Extracted the duplicated entity matching code block into a `_match_humidifier_entity()` helper function that both handlers call, eliminating the duplication while preserving behavior.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
